### PR TITLE
fix populating of envorder array

### DIFF
--- a/lib/chef/knife/Verschart.rb
+++ b/lib/chef/knife/Verschart.rb
@@ -40,7 +40,7 @@ module Verschart
       primary = config[:primary] || []
       order = config[:envorder] || []
       envorder = []
-      envorder = order.split(',') unless order.empty?
+      order.each { |env| envorder << env } unless order.empty? 
       srv = server_url.sub(%r{https://}, '').sub(/:[0-9]*$/, '')
       cbselect = config[:cbselect] || []
       html = config[:html] || false


### PR DESCRIPTION
When setting the environment order via command line, knife verschart would fail due to being unable to run split on an array. This fixes populating the array during the plugin run.

Example:

```
$ knife verschart --primary wlpc-perf -o 'wlpc-dev,wlpc-perf'
ERROR: knife encountered an unexpected error
This may be a bug in the 'verschart' knife command or plugin
Please collect the output of this command with the `-VV` option before filing a bug report.
Exception: NoMethodError: undefined method `split' for ["wlpc-dev", "wlpc-perf"]:Array
```
